### PR TITLE
Kubernetes job

### DIFF
--- a/reindex/README.md
+++ b/reindex/README.md
@@ -1,0 +1,11 @@
+## Reindex Elasticsearch index
+
+The script `reindex.sh` can be used to reindex an index while preserving the old index.
+It creates a new index named `<old-index-name>-reindexed`.
+
+### Reindex using a Kubernetes Job
+
+If you want to run the reindex script as a Kubernetes Job, you can use the [kustomization][1] in this folder.
+Simply edit the `reindexer.env` and the `kubeactl apply -k .`.
+
+[1]: https://kubectl.docs.kubernetes.io/pages/app_customization/introduction.html

--- a/reindex/job.yaml
+++ b/reindex/job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elasticsearch-reindex
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: reindexer
+        image: mintel/docker-alpine-bash-curl-jq
+        command: ["/bin/bash",  "-c", "/reindex/reindex.sh $(INDEXES)"]
+        envFrom:
+          - secretRef:
+              name: reindexer-env
+        volumeMounts:
+          - name: reindex-script
+            mountPath: /reindex/
+      volumes:
+        - name: reindex-script
+          configMap:
+            name: reindex-script
+            defaultMode: 0777

--- a/reindex/kustomization.yaml
+++ b/reindex/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: elastic-system
+
+commonLabels:
+  app.kubernetes.io/name: elasticsearch-reindexer
+
+resources:
+- job.yaml
+
+configMapGenerator:
+  - name: reindex-script
+    files:
+      - reindex.sh
+secretGenerator:
+  - name: reindexer-env
+    env: reindexer.env

--- a/reindex/reindex.sh
+++ b/reindex/reindex.sh
@@ -125,12 +125,10 @@ function reindex () {
 
     log "Task ID: ${task}"
 
-    docs_total=$(curl -ks -X GET "${ES_HOST}/_tasks/${task}" -u "${ES_USER}:${ES_PASSWORD}" | jq '.task.status.total')
-
     while true; do
         status=$(curl -ks -X GET "${ES_HOST}/_tasks/${task}" -u "${ES_USER}:${ES_PASSWORD}" | jq '.completed')
         [ "${status}" = "true" ] && break;
-        # We could get document count from task instead.
+        docs_total=$(curl -ks -X GET "${ES_HOST}/_tasks/${task}" -u "${ES_USER}:${ES_PASSWORD}" | jq '.task.status.total')
         docs_done=$(curl -ks -X GET "${ES_HOST}/_tasks/${task}" -u "${ES_USER}:${ES_PASSWORD}" | jq '.task.status.created')
         log "Waiting for reindexing to complete - ${docs_done} / ${docs_total} documents done."
         sleep 10

--- a/reindex/reindexer.env
+++ b/reindex/reindexer.env
@@ -1,0 +1,4 @@
+# INDEXES=kubernetes-default-YYYY.MM.DD-xxxxxx
+# ES_USER=elastic
+# ES_PASSWORD=xxxxxx
+# ES_HOST=http://elasticsearch-es-http:9200


### PR DESCRIPTION
This makes it possible to run the reindex script as a kubernetes job. It doesn't yet work to list multiple indexes but I didn't really try hard to make it work either.